### PR TITLE
Add option to hide all text in star view

### DIFF
--- a/src/starview.h
+++ b/src/starview.h
@@ -46,7 +46,8 @@ public:
     StarViewConfigDialog(QWidget *parent);
 
     int nodesPerRing();
-    bool suppressDomainName() const;
+    bool shouldSuppressDomainName() const;
+    bool shouldHideAllText() const;
 
     void setMaxNodes(int);
 
@@ -55,6 +56,7 @@ public:
 protected slots:
     void slotNodesPerRingChanged(int nodes);
     void slotSuppressDomainName(bool);
+    void slotHideAllText(bool);
 
 signals:
     void configChanged();
@@ -63,9 +65,9 @@ private:
     QSlider *m_nodesPerRingSlider;
     QLabel *m_nodesPerRingLabel;
     QLineEdit *m_archFilterEdit;
-    QCheckBox *m_suppressDomainName;
+    QCheckBox *m_suppressDomainNameCheckBox;
+    QCheckBox *m_hideAllTextCheckBox;
 };
-
 
 class HostItem : public QGraphicsItemGroup
 {


### PR DESCRIPTION
Support a very simplistic star view configuration in which all nodes and
scheduler are represented by a dot only.
