### PR TITLE
Fix CMakeLists to build with Qt5; make it default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,16 @@
-if (QT5)
-  cmake_minimum_required(VERSION 2.8)
-else(QT5)
-  cmake_minimum_required(VERSION 2.8.8)
-endif(QT5)
+cmake_minimum_required(VERSION 2.8.8)
 
 project(iceberg)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-if (QT5)
-  find_package(Qt 5.0 REQUIRED)
-else(QT5)
+if (NOT QT4)
+  find_package(Qt5Core REQUIRED)
+  find_package(Qt5Gui REQUIRED)
+  find_package(Qt5Widgets REQUIRED)
+else(NOT QT4)
   find_package(Qt 4.8 REQUIRED)
-endif(QT5)
+endif(NOT QT4)
 
 # uninstall target
 configure_file("cmake_uninstall.cmake" "cmake_uninstall.cmake" IMMEDIATE @ONLY)

--- a/README.rst
+++ b/README.rst
@@ -7,5 +7,5 @@ A fork of Icemon, an Icecc monitor, that doesn't depend on KDE libs.
 Build
 =====
 
-By default, Iceberg is built using Qt 4.
-If you want to use Qt 5, run cmake -DQT5=1
+By default, Iceberg is built using Qt 5.
+If you want to use Qt 4, run cmake -DQT4=1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,9 @@
 find_package(Icecream REQUIRED)
 
-if (QT5)
-  find_package(Qt5Widgets REQUIRED)
+if (NOT QT4)
   set(CMAKE_AUTOMOC TRUE)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
-endif(QT5)
+endif(NOT QT4)
 
 add_definitions (${QT_DEFINITIONS} )
 
@@ -29,20 +28,20 @@ set(iceberg_SRCS
   starview.cpp
 )
 
-if (QT5)
+if (NOT QT4)
   qt5_add_resources(iceberg_RCC icons.qrc)
-else(QT5)
+else(NOT QT4)
   qt4_automoc(${iceberg_SRCS})
   qt4_add_resources(iceberg_RCC icons.qrc)
-endif(QT5)
+endif(NOT QT4)
 
 add_executable(iceberg ${iceberg_SRCS} ${iceberg_RCC})
 
 set(ICEBERG_LIBS ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${LIBICECREAM_LIBRARIES} ${QT_QTNETWORK_LIBRARY} ${CMAKE_DL_LIBS})
-if (QT5)
+if (NOT QT4)
   qt5_use_modules(iceberg Widgets)
   set (ICEBERG_LIBS ${ICEBERG_LIBS} ${Qt5Widgets_LIBRARIES})
-endif(QT5)
+endif(NOT QT4)
 
 target_link_libraries(iceberg ${ICEBERG_LIBS})
 


### PR DESCRIPTION
From now on, use -DQT4=1 for builds with Qt4.